### PR TITLE
Implementación de pantalla para perfil propio y perfil de otro usuario

### DIFF
--- a/app/src/main/java/com/example/uvgmarket/core/constants/navigation/ProfileNavGraph.kt
+++ b/app/src/main/java/com/example/uvgmarket/core/constants/navigation/ProfileNavGraph.kt
@@ -9,13 +9,17 @@ fun NavGraphBuilder.profileGraph(navigationActions: NavigationActions) {
     composable(NavigationDestination.Profile.route) {
         val repository = DummyRepository()
 
+        // Pantalla de perfil propio
         ProfileScreen(
             usuario = repository.getUsuario(),
             productos = repository.getProductos(),
             onBackClick = { navigationActions.navigateBack() },
             onChatClick = { /* TODO */ },
             onProductoClick = { navigationActions.navigateToProductDetail() },
-            onFloatingActionClick = { /* TODO */ }
+            onFloatingActionClick = { /* TODO */ },
+            showFloatingActionButton = true,
+            showChatButton = false,
+            showEditButton = true
         )
     }
 }

--- a/app/src/main/java/com/example/uvgmarket/profile/MyProfileScreen.kt
+++ b/app/src/main/java/com/example/uvgmarket/profile/MyProfileScreen.kt
@@ -1,0 +1,53 @@
+package com.example.uvgmarket.profile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.uvgmarket.profile.models.Usuario
+import com.example.uvgmarket.profile.models.Producto
+import com.example.uvgmarket.profile.repository.DummyRepository
+import com.example.uvgmarket.ui.theme.UvgMarketTheme
+
+@Composable
+fun MyProfileScreen(
+    usuario: Usuario,
+    productos: List<Producto> = emptyList(),
+    onBackClick: () -> Unit = {},
+    onProductoClick: (String) -> Unit = {},
+    onEditClick: () -> Unit = {},
+    onAddProductClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    ProfileScreen(
+        usuario = usuario,
+        productos = productos,
+        onBackClick = onBackClick,
+        onProductoClick = onProductoClick,
+        onFloatingActionClick = onAddProductClick,
+        onEditClick = onEditClick,
+        onChatClick = {},
+        showFloatingActionButton = true,
+        showChatButton = false,
+        showEditButton = true,
+        modifier = modifier
+    )
+}
+
+@Preview(
+    showBackground = true,
+    showSystemUi = true
+)
+@Composable
+fun MyProfileScreenPreview() {
+    val repository = DummyRepository()
+    UvgMarketTheme {
+        MyProfileScreen(
+            usuario = repository.getUsuario(),
+            productos = repository.getProductos(),
+            onBackClick = { /* Preview action */ },
+            onProductoClick = { productId -> /* Preview action */ },
+            onEditClick = { /* Preview action */ },
+            onAddProductClick = { /* Preview action */ }
+        )
+    }
+}

--- a/app/src/main/java/com/example/uvgmarket/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/uvgmarket/profile/ProfileScreen.kt
@@ -36,9 +36,15 @@ fun ProfileScreen(
     onBackClick: () -> Unit = {},
     onChatClick: (String) -> Unit = {},
     onProductoClick: (String) -> Unit = {},
-    onFloatingActionClick: () -> Unit = {}
+    onFloatingActionClick: () -> Unit = {},
+    // Parámetros de configuración dependiendo de la pantalla
+    showFloatingActionButton: Boolean = false,
+    showChatButton: Boolean = true,
+    showEditButton: Boolean = false,
+    onEditClick: () -> Unit = {},
+    modifier: Modifier = Modifier
 ) {
-    Box(modifier = Modifier
+    Box(modifier = modifier
         .fillMaxSize()
         .statusBarsPadding()
     ) {
@@ -76,7 +82,10 @@ fun ProfileScreen(
             item {
                 CustomInfoCard(
                     usuario = usuario,
-                    onChatClick = onChatClick
+                    onChatClick = onChatClick,
+                    showChatButton = showChatButton,
+                    showEditButton = showEditButton,
+                    onEditClick = onEditClick
                 )
             }
 
@@ -112,19 +121,24 @@ fun ProfileScreen(
                 .zIndex(1f)
         )
 
-        // Botón flotante circular
-        CustomFloatingActionButton(
-            onClick = onFloatingActionClick,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-        )
+        // Botón flotante circular solo si showFloatingActionButton es true
+        if (showFloatingActionButton) {
+            CustomFloatingActionButton(
+                onClick = onFloatingActionClick,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+            )
+        }
     }
 }
 
-@Preview(showBackground = true)
+@Preview(
+    showBackground = true,
+    showSystemUi = true
+)
 @Composable
-fun PerfilScreenPreview() {
+fun ProfileScreenPreview() {
     val repository = DummyRepository()
     UvgMarketTheme {
         ProfileScreen(

--- a/app/src/main/java/com/example/uvgmarket/profile/components/CustomEditButton.kt
+++ b/app/src/main/java/com/example/uvgmarket/profile/components/CustomEditButton.kt
@@ -1,0 +1,39 @@
+package com.example.uvgmarket.profile.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.uvgmarket.ui.theme.UvgMarketTheme
+
+@Composable
+fun CustomEditButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+    ) {
+        Icon(
+            modifier = Modifier.size(32.dp),
+            imageVector = Icons.Default.Edit,
+            contentDescription = "Editar perfil",
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@Preview
+@Composable
+fun CustomEditButtonPreview() {
+    UvgMarketTheme {
+        CustomEditButton(onClick = {})
+    }
+}

--- a/app/src/main/java/com/example/uvgmarket/profile/components/CustomInfoCard.kt
+++ b/app/src/main/java/com/example/uvgmarket/profile/components/CustomInfoCard.kt
@@ -28,7 +28,10 @@ import com.example.uvgmarket.ui.theme.UvgMarketTheme
 fun CustomInfoCard(
     usuario: Usuario,
     onChatClick: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showChatButton: Boolean = true,
+    showEditButton: Boolean = false,
+    onEditClick: () -> Unit = {}
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -68,9 +71,19 @@ fun CustomInfoCard(
                         modifier = Modifier.weight(1f)
                     )
 
-                    CustomChatButton(
-                        onClick = { onChatClick(usuario.id) }
-                    )
+                    // Mostrar botón de chat solo si showChatButton es true
+                    if (showChatButton) {
+                        CustomChatButton(
+                            onClick = { onChatClick(usuario.id) }
+                        )
+                    }
+
+                    // Mostrar botón de editar solo si showEditButton es true
+                    if (showEditButton) {
+                        CustomEditButton(
+                            onClick = onEditClick
+                        )
+                    }
                 }
 
                 Text(
@@ -93,6 +106,22 @@ fun CustomInfoCardPreview() {
         CustomInfoCard(
             usuario = usuario,
             onChatClick = { /* Preview action */ }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun CustomInfoCardWithEditPreview() {
+    UvgMarketTheme {
+        val repository = DummyRepository()
+        val usuario = repository.getUsuario()
+        CustomInfoCard(
+            usuario = usuario,
+            onChatClick = { /* Preview action */ },
+            showChatButton = false,
+            showEditButton = true,
+            onEditClick = { /* Preview action */ }
         )
     }
 }


### PR DESCRIPTION
Este PR da la posibilidad de editar el perfil del usuario añadiendo un botón de edición a la pantalla de perfil y haciendo la interfaz de usuario más configurable. Los cambios permiten que la pantalla de perfil distinga entre ver el perfil propio y el de otros, mostrando u ocultando los botones de acción según corresponda.

**Configuración y edición de la pantalla de perfil:**

* Se añadieron nuevos parámetros (`showFloatingActionButton`, `showChatButton`, `showEditButton`, `onEditClick` y `modifier`) al componente componible `ProfileScreen`, lo que permite la visualización dinámica de botones flotantes de acción, chat y edición.
* Se actualizó el componente `CustomInfoCard` para mostrar condicionalmente los botones de chat y edición según nuevos indicadores para gestionar el click en el botón de edición mediante una nueva devolución de llamada. 
* Se añadió un nuevo elemento componible `CustomEditButton` para la acción de edición, incluyendo un preview.

**Previews de la interfaz de usuario y mejoras menores:**

* Se actualizaron y añadieron previews de `ProfileScreen` y `CustomInfoCard`.